### PR TITLE
support elasticsearch 2.x

### DIFF
--- a/Dockerfile-2.x
+++ b/Dockerfile-2.x
@@ -7,7 +7,7 @@ USER 0
 
 ENV HOME=/opt/app-root/src \
   JAVA_VER=1.8.0 \
-  ES_VER=2.3.3 \
+  ES_VER=2.3.4 \
   ES_CONF=/usr/share/elasticsearch/config/elasticsearch.yml \
   INSTANCE_RAM=8G \
   NODE_QUORUM=1 \

--- a/Dockerfile-2.x
+++ b/Dockerfile-2.x
@@ -7,7 +7,7 @@ USER 0
 
 ENV HOME=/opt/app-root/src \
   JAVA_VER=1.8.0 \
-  ES_VER=1.5.2 \
+  ES_VER=2.3.3 \
   ES_CONF=/usr/share/elasticsearch/config/elasticsearch.yml \
   INSTANCE_RAM=8G \
   NODE_QUORUM=1 \

--- a/build-image.sh
+++ b/build-image.sh
@@ -4,7 +4,9 @@ set -x
 set -o errexit
 prefix=${PREFIX:-${1:-viaq/}}
 version=${VERSION:-${2:-latest}}
-docker build -t "${prefix}elasticsearch:${version}" .
+docker build  -t "${prefix}elasticsearch:1.5.2" .
+docker tag "${prefix}elasticsearch:1.5.2" "${prefix}elasticsearch:$version"
+docker build -f Dockerfile-2.x -t "${prefix}elasticsearch:2.3.3" .
 
 if [ -n "${PUSH:-$3}" ]; then
 	docker push "${prefix}elasticsearch:${version}"

--- a/build-image.sh
+++ b/build-image.sh
@@ -6,7 +6,7 @@ prefix=${PREFIX:-${1:-viaq/}}
 version=${VERSION:-${2:-latest}}
 docker build  -t "${prefix}elasticsearch:1.5.2" .
 docker tag "${prefix}elasticsearch:1.5.2" "${prefix}elasticsearch:$version"
-docker build -f Dockerfile-2.x -t "${prefix}elasticsearch:2.3.3" .
+docker build -f Dockerfile-2.x -t "${prefix}elasticsearch:2.3.4" .
 
 if [ -n "${PUSH:-$3}" ]; then
 	docker push "${prefix}elasticsearch:${version}"

--- a/elasticsearch.repo
+++ b/elasticsearch.repo
@@ -4,3 +4,10 @@ baseurl=http://packages.elastic.co/elasticsearch/1.5/centos
 gpgcheck=1
 gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
 enabled=1
+
+[elasticsearch-2.x]
+name=Elasticsearch repository for 2.x packages
+baseurl=https://packages.elastic.co/elasticsearch/2.x/centos
+gpgcheck=1
+gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
+enabled=1

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,8 +1,11 @@
+network.host: 0.0.0.0
+
 cluster:
   name: elasticsearch
 
 script:
-  disable_dynamic: false
+  inline: on
+  indexed: on
 
 discovery:
   zen:

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,11 @@
 set -ex
 
 rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
-yum install -y --setopt=tsflags=nodocs \
-  java-1.8.0-openjdk \
+case ${ES_VER:-1.5.2} in
+    1.*) DISABLEREPO="--disablerepo elasticsearch-2.x" ;;
+esac
+yum install -y --setopt=tsflags=nodocs $DISABLEREPO \
+  java-1.8.0-openjdk-headless \
   elasticsearch
 yum clean all
 

--- a/run-container.sh
+++ b/run-container.sh
@@ -4,7 +4,7 @@ set -o errexit
 DB_IN_CONTAINER=${DB_IN_CONTAINER:-0}
 
 if [ "$DB_IN_CONTAINER" = 1 ]; then
-    id=`docker run -d -p 9200:9200 -p 9300:9300 --name viaq-elasticsearch viaq/elasticsearch:latest`
+    id=`docker run -d -e ES_VER=${ES_VER:-1.5.2} -p 9200:9200 -p 9300:9300 --name viaq-elasticsearch viaq/elasticsearch:${ES_VER:-latest}`
 else
     # requires an external mount point and specific external uid
     HOSTDIR=${HOSTDIR:-/var/lib/viaq}
@@ -15,7 +15,7 @@ else
         sudo chcon -Rt svirt_sandbox_file_t $ESHOSTDIR
     fi
     uid=`id -u`
-    id=`docker run -d -p 9200:9200 -p 9300:9300 -u $uid --name viaq-elasticsearch -v $ESHOSTDIR:/elasticsearch viaq/elasticsearch:latest`
+    id=`docker run -d -e ES_VER=${ES_VER:-1.5.2} -p 9200:9200 -p 9300:9300 -u $uid --name viaq-elasticsearch -v $ESHOSTDIR:/elasticsearch viaq/elasticsearch:${ES_VER:-latest}`
 fi
 
 echo $id

--- a/run.sh
+++ b/run.sh
@@ -45,7 +45,7 @@ fi
 wait_for_port_open() {
     rm -f ${LOG_FILE}
     echo -n "Checking if Elasticsearch is ready on ${HOST}:${PORT} "
-    while ! curl -s --max-time ${max_time} -o ${LOG_FILE} ${HOST}:${PORT} && [ ${timeouted} == false ]
+    while ! curl -i -s --max-time ${max_time} -o ${LOG_FILE} ${HOST}:${PORT} && [ ${timeouted} == false ]
     do
         echo -n "."
         sleep ${RETRY_INTERVAL}
@@ -56,12 +56,14 @@ wait_for_port_open() {
     done
 
     # Test for response code 200 in Elasticsearch output. This can be sensitive to Elasticsearch version.
-    if [ -f ${LOG_FILE} ] && grep -q "200" ${LOG_FILE} ; then
+    if [ -f ${LOG_FILE} ] && grep -q "HTTP/1.1 200 OK" ${LOG_FILE} ; then
         echo "- connection successful"
+        cat ${LOG_FILE}
     else
         if [ ${timeouted} == true ] ; then
             echo -n "[timeout] "
         fi
+        cat ${LOG_FILE}
         echo "failed"
         exit 1
     fi


### PR DESCRIPTION
@lukas-vlcek @t0ffel PTAL

By default, elasticsearch 1.5.2 is used.  You have to explicitly specify to use the viaq/elasticsearch:2.3.3 image.  I could not figure out how parameterize the build, so I had to create Dockerfile-2.x for building the 2.x version.
